### PR TITLE
Handle arithmetic overflows in circuit recipe permutation calculations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1644349045
+//version: 1652851397
 /*
 DO NOT CHANGE THIS FILE!
 
@@ -9,26 +9,28 @@ Please check https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/build.g
 
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.internal.logging.text.StyledTextOutput.Style
+import org.gradle.internal.logging.text.StyledTextOutputFactory
 
 import java.util.concurrent.TimeUnit
 
 buildscript {
     repositories {
         maven {
-            name = "forge"
-            url = "https://maven.minecraftforge.net"
+            name 'forge'
+            url 'https://maven.minecraftforge.net'
         }
         maven {
-            name = "sonatype"
-            url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            name 'sonatype'
+            url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
         maven {
-            name = "Scala CI dependencies"
-            url = "https://repo1.maven.org/maven2/"
+            name 'Scala CI dependencies'
+            url 'https://repo1.maven.org/maven2/'
         }
         maven {
-            name = "jitpack"
-            url = "https://jitpack.io"
+            name 'jitpack'
+            url 'https://jitpack.io'
         }
     }
     dependencies {
@@ -37,20 +39,26 @@ buildscript {
 }
 
 plugins {
+    id 'java-library'
     id 'idea'
     id 'eclipse'
     id 'scala'
     id 'maven-publish'
-    id('org.jetbrains.kotlin.jvm') version ('1.6.10') apply false
-    id('org.ajoberstar.grgit') version('4.1.1')
-    id('com.github.johnrengelman.shadow') version('4.0.4')
-    id('com.palantir.git-version') version('0.13.0') apply false
-    id('de.undercouch.download') version('5.0.1')
+    id 'org.jetbrains.kotlin.jvm'        version '1.5.30'       apply false
+    id 'org.jetbrains.kotlin.kapt'       version '1.5.30'       apply false
+    id 'com.google.devtools.ksp'         version '1.5.30-1.0.0' apply false
+    id 'org.ajoberstar.grgit'            version '4.1.1'
+    id 'com.github.johnrengelman.shadow' version '4.0.4'
+    id 'com.palantir.git-version'        version '0.13.0'       apply false
+    id 'de.undercouch.download'          version '5.0.1'
+    id 'com.github.gmazzo.buildconfig'   version '3.0.3'        apply false
 }
 
 if (project.file('.git/HEAD').isFile()) {
     apply plugin: 'com.palantir.git-version'
 }
+
+def out = services.get(StyledTextOutputFactory).create('an-output')
 
 apply plugin: 'forge'
 
@@ -96,6 +104,7 @@ checkPropertyExists("usesShadowedDependencies")
 checkPropertyExists("developmentEnvironmentUserName")
 
 boolean noPublishedSources = project.findProperty("noPublishedSources") ? project.noPublishedSources.toBoolean() : false
+boolean usesMixinDebug = project.findProperty('usesMixinDebug') ?: project.usesMixins.toBoolean()
 
 String javaSourceDir = "src/main/java/"
 String scalaSourceDir = "src/main/scala/"
@@ -167,8 +176,8 @@ configurations.all {
 try {
     'git config core.fileMode false'.execute()
 }
-catch (Exception e) {
-    logger.error("\u001B[31mgit isn't installed at all\u001B[0m")
+catch (Exception ignored) {
+    out.style(Style.Failure).println("git isn't installed at all")
 }
 
 // Pulls version first from the VERSION env and then git tag
@@ -177,19 +186,22 @@ String versionOverride = System.getenv("VERSION") ?: null
 try {
     identifiedVersion = versionOverride == null ? gitVersion() : versionOverride
 }
-catch (Exception e) {
-    logger.error("\n\u001B[1;31mThis mod must be version controlled by Git AND the repository must provide at least one tag,\n" +
-                 "or the VERSION override must be set! \u001B[32m(Don't download from GitHub using the ZIP option, instead\n" +
-                 "clone the repository, see\u001B[33m https://gtnh.miraheze.org/wiki/Development \u001B[32mfor details.)\u001B[0m\n");
+catch (Exception ignored) {
+    out.style(Style.Failure).text(
+        'This mod must be version controlled by Git AND the repository must provide at least one tag,\n' +
+        'or the VERSION override must be set! ').style(Style.SuccessHeader).text('(Do NOT download from GitHub using the ZIP option, instead\n' +
+        'clone the repository, see ').style(Style.Info).text('https://gtnh.miraheze.org/wiki/Development').style(Style.SuccessHeader).println(' for details.)'
+    )
     versionOverride = 'NO-GIT-TAG-SET'
     identifiedVersion = versionOverride
 }
 version = minecraftVersion + '-' + identifiedVersion
-String modVersion = identifiedVersion
+ext {
+    modVersion = identifiedVersion
+}
 
-if( identifiedVersion.equals(versionOverride) ) {
-    logger.error('\u001B[31m\u001B[7mWe hope you know what you\'re doing using\u001B[0m\u001B[1;34m ' + modVersion + '\u001B[0m\n');
-    logger.error('\7\u001B[31mGoing to blindly try to use\u001B[1;34m ' + modVersion + '\u001B[0m\u001B[31m, this probably won\'t work the way you expect!!\u001B[0m\n');
+if(identifiedVersion == versionOverride) {
+    out.style(Style.Failure).text('Override version to ').style(Style.Identifier).text(modVersion).style(Style.Failure).println('!\7')
 }
 
 group = modGroup
@@ -200,22 +212,25 @@ else {
     archivesBaseName = modId
 }
 
-
 def arguments = []
 def jvmArguments = []
 
-if(usesMixins.toBoolean()) {
+if (usesMixins.toBoolean()) {
     arguments += [
-            "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
+        "--tweakClass org.spongepowered.asm.launch.MixinTweaker"
     ]
-    jvmArguments += [
-            "-Dmixin.debug.countInjections=true", "-Dmixin.debug.verbose=true", "-Dmixin.debug.export=true"
-    ]
+    if (usesMixinDebug.toBoolean()) {
+        jvmArguments += [
+            "-Dmixin.debug.countInjections=true",
+            "-Dmixin.debug.verbose=true",
+            "-Dmixin.debug.export=true"
+        ]
+    }
 }
 
 minecraft {
-    version = minecraftVersion + "-" + forgeVersion + "-" + minecraftVersion
-    runDir = "run"
+    version = minecraftVersion + '-' + forgeVersion + '-' + minecraftVersion
+    runDir = 'run'
 
     if (replaceGradleTokenInFile) {
         replaceIn replaceGradleTokenInFile
@@ -248,8 +263,8 @@ minecraft {
     }
 }
 
-if(file("addon.gradle").exists()) {
-    apply from: "addon.gradle"
+if(file('addon.gradle').exists()) {
+    apply from: 'addon.gradle'
 }
 
 apply from: 'repositories.gradle'
@@ -262,58 +277,63 @@ configurations {
 
 repositories {
     maven {
-        name = "Overmind forge repo mirror"
-        url = "https://gregtech.overminddl1.com/"
+        name 'Overmind forge repo mirror'
+        url 'https://gregtech.overminddl1.com/'
     }
     if(usesMixins.toBoolean()) {
         maven {
-            name = "sponge"
-            url = "https://repo.spongepowered.org/repository/maven-public"
+            name 'sponge'
+            url 'https://repo.spongepowered.org/repository/maven-public'
         }
         maven {
-            url = "https://jitpack.io"
+            url 'https://jitpack.io'
         }
     }
 }
 
 dependencies {
     if(usesMixins.toBoolean()) {
-        annotationProcessor("org.ow2.asm:asm-debug-all:5.0.3")
-        annotationProcessor("com.google.guava:guava:24.1.1-jre")
-        annotationProcessor("com.google.code.gson:gson:2.8.6")
-        annotationProcessor("org.spongepowered:mixin:0.8-SNAPSHOT")
+        annotationProcessor('org.ow2.asm:asm-debug-all:5.0.3')
+        annotationProcessor('com.google.guava:guava:24.1.1-jre')
+        annotationProcessor('com.google.code.gson:gson:2.8.6')
+        annotationProcessor('org.spongepowered:mixin:0.8-SNAPSHOT')
         // using 0.8 to workaround a issue in 0.7 which fails mixin application
-        compile("com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH") {
+        compile('com.github.GTNewHorizons:SpongePoweredMixin:0.7.12-GTNH') {
             // Mixin includes a lot of dependencies that are too up-to-date
-            exclude module: "launchwrapper"
-            exclude module: "guava"
-            exclude module: "gson"
-            exclude module: "commons-io"
-            exclude module: "log4j-core"
+            exclude module: 'launchwrapper'
+            exclude module: 'guava'
+            exclude module: 'gson'
+            exclude module: 'commons-io'
+            exclude module: 'log4j-core'
         }
-        compile("com.github.GTNewHorizons:SpongeMixins:1.5.0")
+        compile('com.github.GTNewHorizons:SpongeMixins:1.5.0')
     }
 }
 
 apply from: 'dependencies.gradle'
 
-def mixingConfigRefMap = "mixins." + modId + ".refmap.json"
+def mixingConfigRefMap = 'mixins.' + modId + '.refmap.json'
 def refMap = "${tasks.compileJava.temporaryDir}" + File.separator + mixingConfigRefMap
 def mixinSrg = "${tasks.reobf.temporaryDir}" + File.separator + "mixins.srg"
 
 task generateAssets {
-    if(usesMixins.toBoolean()) {
-        getFile("/src/main/resources/mixins." + modId + ".json").text = """{
+    if (usesMixins.toBoolean()) {
+        def mixinConfigFile = getFile("/src/main/resources/mixins." + modId + ".json");
+        if (!mixinConfigFile.exists()) {
+            mixinConfigFile.text = """{
   "required": true,
   "minVersion": "0.7.11",
   "package": "${modGroup}.${mixinsPackage}",
   "plugin": "${modGroup}.${mixinPlugin}",
   "refmap": "${mixingConfigRefMap}",
   "target": "@env(DEFAULT)",
-  "compatibilityLevel": "JAVA_8"
+  "compatibilityLevel": "JAVA_8",
+  "mixins": [],
+  "client": [],
+  "server": []
 }
-
 """
+        }
     }
 }
 
@@ -401,12 +421,11 @@ tasks.withType(JavaExec).configureEach {
     )
 }
 
-processResources
-{
+processResources {
     // this will ensure that this task is redone when the versions change.
     inputs.property "version", project.version
     inputs.property "mcversion", project.minecraft.version
-    
+
     // replace stuff in mcmod.info, nothing else
     from(sourceSets.main.resources.srcDirs) {
         include 'mcmod.info'
@@ -430,7 +449,7 @@ processResources
 
 def getManifestAttributes() {
     def manifestAttributes = [:]
-    if(containsMixinsAndOrCoreModOnly.toBoolean() == false && (usesMixins.toBoolean() || coreModClass)) {
+    if(!containsMixinsAndOrCoreModOnly.toBoolean() && (usesMixins.toBoolean() || coreModClass)) {
         manifestAttributes += ["FMLCorePluginContainsFMLMod": true]
     }
 
@@ -446,14 +465,14 @@ def getManifestAttributes() {
         manifestAttributes += [
                 "TweakClass" : "org.spongepowered.asm.launch.MixinTweaker",
                 "MixinConfigs" : "mixins." + modId + ".json",
-                "ForceLoadAsMod" : containsMixinsAndOrCoreModOnly.toBoolean() == false
+                "ForceLoadAsMod" : !containsMixinsAndOrCoreModOnly.toBoolean()
         ]
     }
     return manifestAttributes
 }
 
 task sourcesJar(type: Jar) {
-    from (sourceSets.main.allJava)
+    from (sourceSets.main.allSource)
     from (file("$projectDir/LICENSE"))
     getArchiveClassifier().set('sources')
 }
@@ -508,7 +527,7 @@ task devJar(type: Jar) {
 }
 
 task apiJar(type: Jar) {
-    from (sourceSets.main.allJava) {
+    from (sourceSets.main.allSource) {
         include modGroup.toString().replaceAll("\\.", "/") + "/" + apiPackage.toString().replaceAll("\\.", "/") + '/**'
     }
 
@@ -533,11 +552,14 @@ artifacts {
     }
 }
 
-// The gradle metadata includes all of the additional deps that we disabled from POM generation (including forgeBin with no groupID), 
+// The gradle metadata includes all of the additional deps that we disabled from POM generation (including forgeBin with no groupID),
 // and isn't strictly needed with the POM so just disable it.
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
+
+// workaround variable hiding in pom processing
+def projectConfigs = project.configurations
 
 publishing {
     publications {
@@ -547,7 +569,7 @@ publishing {
                 artifact source: shadowJar, classifier: ""
             }
             if(!noPublishedSources) {
-                artifact source: sourcesJar, classifier: "src"
+                artifact source: sourcesJar, classifier: "sources"
             }
             artifact source: usesShadowedDependencies.toBoolean() ? shadowDevJar : devJar, classifier: "dev"
             if (apiPackage) {
@@ -558,17 +580,21 @@ publishing {
             artifactId = System.getenv("ARTIFACT_ID") ?: project.name
             // Using the identified version, not project.version as it has the prepended 1.7.10
             version = System.getenv("RELEASE_VERSION") ?: identifiedVersion
-            
-            // remove extra garbage from who knows where
+
+            // remove extra garbage from minecraft and minecraftDeps configuration
             pom.withXml {
-                def badPomGroup = ['net.minecraft', 'com.google.code.findbugs', 'org.ow2.asm', 'com.typesafe.akka', 'com.typesafe', 'org.scala-lang',
-                                   'org.scala-lang.plugins', 'net.sf.jopt-simple', 'lzma', 'com.mojang', 'org.apache.commons', 'org.apache.httpcomponents',
-                                   'commons-logging', 'java3d', 'net.sf.trove4j', 'com.ibm.icu', 'com.paulscode', 'io.netty', 'com.google.guava', 
-                                   'commons-io', 'commons-codec', 'net.java.jinput', 'net.java.jutils', 'com.google.code.gson', 'org.apache.logging.log4j', 
-                                   'org.lwjgl.lwjgl', 'tv.twitch', '']
+                def badArtifacts = [:].withDefault {[] as Set<String>}
+                for (configuration in [projectConfigs.minecraft, projectConfigs.minecraftDeps]) {
+                    for (dependency in configuration.allDependencies) {
+                        badArtifacts[dependency.group == null ? "" : dependency.group] += dependency.name
+                    }
+                }
+                // example for specifying extra stuff to ignore
+                // badArtifacts["org.example.group"] += "artifactName"
+
                 Node pomNode = asNode()
                 pomNode.dependencies.'*'.findAll() {
-                    badPomGroup.contains(it.groupId.text()) 
+                    badArtifacts[it.groupId.text()].contains(it.artifactId.text())
                 }.each() {
                     it.parent().remove(it)
                 }
@@ -600,7 +626,7 @@ if (isNewBuildScriptVersionAvailable(projectDir.toString())) {
     if (autoUpdateBuildScript.toBoolean()) {
         performBuildScriptUpdate(projectDir.toString())
     } else {
-        println("Build script update available! Run 'gradle updateBuildScript'")
+        out.style(Style.SuccessHeader).println("Build script update available! Run 'gradle updateBuildScript'")
     }
 }
 
@@ -612,7 +638,7 @@ boolean performBuildScriptUpdate(String projectDir) {
     if (isNewBuildScriptVersionAvailable(projectDir)) {
         def buildscriptFile = getFile("build.gradle")
         availableBuildScriptUrl().withInputStream { i -> buildscriptFile.withOutputStream { it << i } }
-        print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
+        out.style(Style.Success).print("Build script updated. Please REIMPORT the project or RESTART your IDE!")
         return true
     }
     return false
@@ -681,7 +707,7 @@ def deobf(String sourceURL, String fileName) {
     String bon2File  = bon2Dir + "/BON2-2.5.0.jar"
     String obfFile = cacheDir + "modules-2/files-2.1/" + fileName + ".jar"
     String deobfFile = cacheDir + "modules-2/files-2.1/" + fileName + "-deobf.jar"
-    
+
     if(file(deobfFile).exists()) {
         return files(deobfFile)
     }
@@ -712,7 +738,7 @@ def deobf(String sourceURL, String fileName) {
 // Helper methods
 
 def checkPropertyExists(String propertyName) {
-    if (project.hasProperty(propertyName) == false) {
+    if (!project.hasProperty(propertyName)) {
         throw new GradleException("This project requires a property \"" + propertyName + "\"! Please add it your \"gradle.properties\". You can find all properties and their description here: https://github.com/GTNewHorizons/ExampleMod1.7.10/blob/main/gradle.properties")
     }
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:NotEnoughItems:2.2.6-GTNH:dev')
+    compile('com.github.GTNewHorizons:NotEnoughItems:2.2.12-GTNH:dev')
 
     compileOnly('com.github.GTNewHorizons:NewHorizonsCoreMod:1.9.20:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.40.33:dev') {transitive=false}

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/circuits/CircuitRecipe.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/circuits/CircuitRecipe.java
@@ -141,13 +141,21 @@ abstract class CircuitRecipe {
         ImmutableSortedSet<DisplayComponent> fluidInputs = fluidInputsBuilder.build();
 
         boolean missingCombinations = false;
-        int expectedNumberOfRecipes = fluidInputs.size();
-        expectedNumberOfRecipes *=
-                itemInputs.stream().mapToInt(Set::size).reduce(1, Math::multiplyExact);
-        expectedNumberOfRecipes /=
-                recipes.stream()
-                        .mapToInt(Recipe::itemInputsPermutationMultiplier)
-                        .reduce(1, Math::multiplyExact);
+        long expectedNumberOfRecipes = fluidInputs.size();
+        try {
+            expectedNumberOfRecipes *=
+                    itemInputs.stream().mapToLong(Set::size).reduce(1, Math::multiplyExact);
+            expectedNumberOfRecipes /=
+                    recipes.stream()
+                            .mapToLong(Recipe::itemInputsPermutationMultiplier)
+                            .reduce(1, Math::multiplyExact);
+        } catch (ArithmeticException e) {
+            Logger.GREGTECH_5_CIRCUITS.error(
+                    "Arithmetic exception when calculating number of recipes for circuit "
+                            + output.toPrettyString(), e);
+            // Assume a valid number of recipes when calculation fails
+            expectedNumberOfRecipes = recipes.size();
+        }
         if (expectedNumberOfRecipes != recipes.size()) {
             Logger.GREGTECH_5_CIRCUITS.warn(
                     "Expected {} recipes but got {} for circuit: [{}]",


### PR DESCRIPTION
Should prevent crashes when the calculation of number of permutations of circuit recipes fails, also switched the type to long to reduce the chance of it failing in the first place