### PR TITLE
Add missing EBF coils and scan EBF recipes for precise temperature values

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,17 +1,17 @@
 // Add your dependencies here
 
 dependencies {
-    compile('com.github.GTNewHorizons:NotEnoughItems:2.2.12-GTNH:dev')
+    compile('com.github.GTNewHorizons:NotEnoughItems:2.3.6-GTNH:dev')
 
-    compileOnly('com.github.GTNewHorizons:NewHorizonsCoreMod:1.9.20:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.40.33:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:bartworks:0.5.36:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:NewHorizonsCoreMod:1.9.79:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.49:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:bartworks:0.5.84:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:GTplusplus:1.7.27:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:EnderStorage:1.4.11:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:DetravScannerMod:1.6.5:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:ForestryMC:4.4.5:api') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:Railcraft:9.13.6:api') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.3.1.29:api') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:EnderStorage:1.4.12:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:DetravScannerMod:1.6.9:dev') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:ForestryMC:4.4.14:api') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:Railcraft:9.13.10:api') {transitive=false}
+    compileOnly('com.github.GTNewHorizons:EnderIO:2.3.1.44:api') {transitive=false}
     compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.27:api') {transitive=false}
 
     compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -3,19 +3,28 @@
 dependencies {
     compile('com.github.GTNewHorizons:NotEnoughItems:2.3.6-GTNH:dev')
 
-    compileOnly('com.github.GTNewHorizons:NewHorizonsCoreMod:1.9.79:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.49:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:bartworks:0.5.84:dev') {transitive=false}
+    compile('com.github.GTNewHorizons:NewHorizonsCoreMod:1.9.79:dev') {transitive=false}
+    compile('com.github.GTNewHorizons:GT5-Unofficial:5.09.41.49:dev') {transitive=false}
+    compile('com.github.GTNewHorizons:bartworks:0.5.84:dev') {transitive=false}
     compileOnly('com.github.GTNewHorizons:GTplusplus:1.7.27:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:EnderStorage:1.4.12:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:DetravScannerMod:1.6.9:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:ForestryMC:4.4.14:api') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:Railcraft:9.13.10:api') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:EnderIO:2.3.1.44:api') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:BuildCraft:7.1.27:api') {transitive=false}
+    compile('com.github.GTNewHorizons:EnderStorage:1.4.12:dev') {transitive=false}
+    compile('com.github.GTNewHorizons:DetravScannerMod:1.6.9:dev') {transitive=false}
+    compile('com.github.GTNewHorizons:ForestryMC:4.4.14:api') {transitive=false}
+    compile('com.github.GTNewHorizons:Railcraft:9.13.10:api') {transitive=false}
+    compile('com.github.GTNewHorizons:EnderIO:2.3.1.44:api') {transitive=false}
+    compile('com.github.GTNewHorizons:BuildCraft:7.1.27:api') {transitive=false}
 
-    compileOnly('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
+    compile('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
+    runtime("curse.maven:cofh-core-69162:2388751")
+    runtime('curse.maven:advsolar-362768:2885953')
+
+    runtime('com.github.GTNewHorizons:Baubles:1.0.1.14:dev')
+    runtime('com.github.GTNewHorizons:Yamcl:0.5.84:dev')
+    runtime('com.github.GTNewHorizons:StructureLib:1.2.0-beta.2:dev')
+    runtime('com.github.GTNewHorizons:GTNHLib:0.0.5:dev')
+    runtime('com.github.GTNewHorizons:Chisel:2.10.10-GTNH:dev')
+    runtime('com.github.GTNewHorizons:waila:1.5.22:dev')
+
     compileOnly('com.google.auto.value:auto-value-annotations:1.8.2') {transitive=false}
-
     annotationProcessor('com.google.auto.value:auto-value:1.8.2')
 }

--- a/repositories.gradle
+++ b/repositories.gradle
@@ -15,6 +15,9 @@ repositories {
         }
     }
     maven {
+        url "https://cursemaven.com"
+    }
+    maven {
         url = "https://jitpack.io"
     }
 }

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/api/diagram/DiagramGroup.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/api/diagram/DiagramGroup.java
@@ -333,7 +333,7 @@ public class DiagramGroup implements ICraftingHandler, IUsageHandler {
 
     /** We have our own custom tooltip drawing code. */
     @Override
-    public List<String> handleTooltip(GuiRecipe gui, List<String> currenttip, int recipe) {
+    public List<String> handleTooltip(GuiRecipe<?> gui, List<String> currenttip, int recipe) {
         // Call our custom tooltip logic. It must be called here rather than in drawForeground(),
         // because calling it in drawForeground() will cause it to be drawn under NEI side panels.
         drawTooltip(gui, recipe);
@@ -344,7 +344,7 @@ public class DiagramGroup implements ICraftingHandler, IUsageHandler {
     /** We have our own custom tooltip drawing code. */
     @Override
     public List<String> handleItemTooltip(
-            GuiRecipe gui, ItemStack stack, List<String> currenttip, int recipe) {
+            GuiRecipe<?> gui, ItemStack stack, List<String> currenttip, int recipe) {
         return currenttip;
     }
 

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/materialparts/DiagramFactory.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/materialparts/DiagramFactory.java
@@ -19,11 +19,16 @@ import com.google.common.collect.ImmutableList;
 import gregtech.api.enums.ItemList;
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.OrePrefixes;
+import gregtech.api.objects.ItemData;
+import gregtech.api.util.GT_OreDictUnificator;
+import gregtech.api.util.GT_Recipe;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.fluids.FluidStack;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -107,6 +112,7 @@ class DiagramFactory {
     private final LayoutHandler layoutHandler;
     private final HeatingCoilHandler heatingCoilHandler;
     private final RelatedMaterialsHandler relatedMaterialsHandler;
+    private final HashMap<Materials, Integer> materialEbfHeatMap = new HashMap<>();
 
     DiagramFactory(
             LayoutHandler layoutHandler, HeatingCoilHandler heatingCoilHandler,
@@ -114,6 +120,19 @@ class DiagramFactory {
         this.layoutHandler = layoutHandler;
         this.heatingCoilHandler = heatingCoilHandler;
         this.relatedMaterialsHandler = relatedMaterialsHandler;
+    }
+
+    void initialize() {
+        for (GT_Recipe ebfRecipe : GT_Recipe.GT_Recipe_Map.sBlastRecipes.mRecipeList) {
+            for (ItemStack output : ebfRecipe.mOutputs) {
+                ItemData outData = GT_OreDictUnificator.getAssociation(output);
+                if ((outData != null) && outData.hasValidMaterialData() && outData.hasValidPrefixData() && (outData.mPrefix == OrePrefixes.ingot || outData.mPrefix == OrePrefixes.ingotHot)) {
+                    Materials mat = outData.mMaterial.mMaterial;
+                    int recipeHeat = ebfRecipe.mSpecialValue;
+                    materialEbfHeatMap.compute(mat, (m, oldHeat) -> (oldHeat == null) ? recipeHeat : Math.min(recipeHeat, oldHeat));
+                }
+            }
+        }
     }
 
     Diagram buildDiagram(Materials material) {
@@ -204,12 +223,13 @@ class DiagramFactory {
         if (!material.mBlastFurnaceRequired) {
             return Optional.empty();
         }
+        int ebfTemp = materialEbfHeatMap.getOrDefault(material, (int) material.mBlastFurnaceTemp);
 
         Tooltip.Builder tooltipBuilder = Tooltip.builder().setFormatting(Tooltip.INFO_FORMATTING);
-        if (material.mBlastFurnaceTemp > 0) {
+        if (ebfTemp > 0) {
             tooltipBuilder.addTextLine(
                             Lang.GREGTECH_5_MATERIAL_PARTS.transf(
-                                    "blastfurnaceinfotemp", material.mBlastFurnaceTemp))
+                                    "blastfurnaceinfotemp", ebfTemp))
                     .addSpacing()
                     .setFormatting(Tooltip.SLOT_FORMATTING)
                     .addTextLine(
@@ -217,7 +237,7 @@ class DiagramFactory {
                     .setFormatting(Tooltip.DEFAULT_FORMATTING);
 
             for (Map.Entry<Long, Component> entry :
-                    heatingCoilHandler.getHeatingCoils(material.mBlastFurnaceTemp).entrySet()) {
+                    heatingCoilHandler.getHeatingCoils(ebfTemp).entrySet()) {
                 long heat = entry.getKey();
                 Component heatingCoil = entry.getValue();
 

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/materialparts/GregTechMaterialParts.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/materialparts/GregTechMaterialParts.java
@@ -70,6 +70,7 @@ public final class GregTechMaterialParts implements DiagramGenerator {
         layoutHandler.initialize();
         heatingCoilHandler.initialize();
         relatedMaterialsHandler.initialize();
+        diagramFactory.initialize();
 
         ImmutableBiMap.Builder<Materials, Diagram> materialsMapBuilder = ImmutableBiMap.builder();
         for (Materials material : Materials.getAll()) {

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/materialparts/HeatingCoilHandler.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/materialparts/HeatingCoilHandler.java
@@ -22,7 +22,10 @@ class HeatingCoilHandler {
                     ItemList.Casing_Coil_ElectrumFlux,
                     ItemList.Casing_Coil_AwakenedDraconium,
                     ItemList.Casing_Coil_HSSS,
-                    ItemList.Casing_Coil_Trinium);
+                    ItemList.Casing_Coil_Trinium,
+                    ItemList.Casing_Coil_Infinity,
+                    ItemList.Casing_Coil_Hypogen,
+                    ItemList.Casing_Coil_Eternal);
 
     /** Sorted map of blast furnace recipe heat to heating coil item. */
     private ImmutableSortedMap<Long, Component> heatingCoilMap;

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/main/NeiIntegration.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/main/NeiIntegration.java
@@ -56,7 +56,7 @@ public enum NeiIntegration {
             }
 
             DiagramGroup diagramGroup = diagramGroupOptional.get();
-            for (int i : ((GuiRecipe) guiContainer).getRecipeIndices()) {
+            for (int i : ((GuiRecipe<?>) guiContainer).getRecipeIndices()) {
                 Optional<ItemStack> itemStackOptional = diagramGroup.getStackUnderMouse(i);
                 if (itemStackOptional.isPresent()) {
                     return itemStackOptional.get();


### PR DESCRIPTION
The coremod adds quite a lot of ebf recipes for materials not exactly following the materials' `mBlastFurnaceTemp` field, so this changes the diagrams to scan EBF recipes directly for the temperatures instead.

Fixes <https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/11391>