### PR TITLE
Make Ore Processing Diagram chemical bath recipe handler handle any input fluid amount

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.7'
+        classpath 'com.github.GTNewHorizons:ForgeGradle:1.2.13'
     }
 }
 

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/DiagramBuilder.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/DiagramBuilder.java
@@ -296,20 +296,21 @@ class DiagramBuilder {
     private void handleChemicalBathFluid(
             RecipeHandler.ChemicalBathFluid chemicalBathFluid, ItemComponent input,
             Layout.SlotGroupKey key) {
-        Optional<ImmutableList<DisplayComponent>> outputsOptional =
+        Optional<RecipeHandler.ChemicalBathFluidRecipe> recipeOptional =
                 recipeHandler.getUniqueChemicalBathOutput(chemicalBathFluid, input);
-        if (!outputsOptional.isPresent()) {
+        if (!recipeOptional.isPresent()) {
             return;
         }
 
-        DisplayComponent fluid = chemicalBathFluid.fluid;
+        DisplayComponent fluid = DisplayComponent.builder(chemicalBathFluid.fluid)
+                .setStackSize(recipeOptional.get().inputFluidAmount()).build();
         Optional<DisplayComponent> fluidDisplayItem =
                 GregTechFluidDictUtil.getDisplayItem(fluid.component())
                         .map(
                                 itemComponent ->
                                         fluid.toBuilder().setComponent(itemComponent).build());
 
-        List<DisplayComponent> outputs = new ArrayList<>(outputsOptional.get());
+        List<DisplayComponent> outputs = new ArrayList<>(recipeOptional.get().outputs());
         ComponentTransformer.removeComponent(outputs, STONE_DUST);
         if (outputs.size() == 0) {
             Logger.GREGTECH_5_ORE_PROCESSING.warn(


### PR DESCRIPTION
 * Make Ore Processing Diagram chemical bath recipe handler handle any input fluid amount
   + Fluid amounts were previously hard-coded: 1000 for mercury, and 100 for sodium persulfate
 * Fixes GTNewHorizons/GT-New-Horizons-Modpack#11842