### PR TITLE
Prevent custom diagrams from overriding NEI tab scrolling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1683563728
+//version: 1685785062
 /*
  DO NOT CHANGE THIS FILE!
  Also, you may replace this file at any time if there is an update available.
@@ -69,7 +69,7 @@ plugins {
     id 'com.diffplug.spotless' version '6.13.0' apply false // 6.13.0 is the last jvm8 supporting version
     id 'com.modrinth.minotaur' version '2.+' apply false
     id 'com.matthewprenger.cursegradle' version '1.4.0' apply false
-    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.7'
+    id 'com.gtnewhorizons.retrofuturagradle' version '1.3.14'
 }
 
 print("You might want to check out './gradlew :faq' if your build fails.\n")
@@ -569,9 +569,10 @@ repositories {
 
 def mixinProviderGroup = "io.github.legacymoddingmc"
 def mixinProviderModule = "unimixins"
-def mixinProviderVersion = "0.1.6"
+def mixinProviderVersion = "0.1.7.1"
 def mixinProviderSpecNoClassifer = "${mixinProviderGroup}:${mixinProviderModule}:${mixinProviderVersion}"
 def mixinProviderSpec = "${mixinProviderSpecNoClassifer}:dev"
+ext.mixinProviderSpec = mixinProviderSpec
 
 dependencies {
     if (usesMixins.toBoolean()) {
@@ -729,7 +730,7 @@ dependencies {
         java17Dependencies("com.github.GTNewHorizons:lwjgl3ify:${lwjgl3ifyVersion}")
     }
     if (modId != 'hodgepodge') {
-        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.8')
+        java17Dependencies('com.github.GTNewHorizons:Hodgepodge:2.2.13')
     }
 
     java17PatchDependencies('net.minecraft:launchwrapper:1.15') {transitive = false}
@@ -821,6 +822,18 @@ public abstract class RunHotswappableMinecraftTask extends RunMinecraftTask {
             !file.path.contains("2.9.4-nightly-20150209") // Remove lwjgl2
         }
         this.classpath(project.java17DependenciesCfg)
+    }
+
+    public void setup(Project project) {
+        super.setup(project)
+        if (project.usesMixins.toBoolean()) {
+            this.extraJvmArgs.addAll(project.provider(() -> {
+                def mixinCfg = project.configurations.detachedConfiguration(project.dependencies.create(project.mixinProviderSpec))
+                mixinCfg.canBeConsumed = false
+                mixinCfg.transitive = false
+                enableHotswap ? ["-javaagent:" + mixinCfg.singleFile.absolutePath] : []
+            }))
+        }
     }
 }
 
@@ -1263,12 +1276,14 @@ tasks.register('faq') {
     description = 'Prints frequently asked questions about building a project'
 
     doLast {
-        print("If your build fails to fetch dependencies, they might have been deleted and replaced by newer " +
-            "versions.\nCheck if the versions you try to fetch are still on the distributing sites.\n" +
-            "The links can be found in repositories.gradle and build.gradle:repositories, " +
-            "not build.gradle:buildscript.repositories - this one is for gradle plugin metadata.\n\n" +
+        print("If your build fails to fetch dependencies, run './gradlew updateDependencies'. " +
+            "Or you can manually check if the versions are still on the distributing sites - " +
+            "the links can be found in repositories.gradle and build.gradle:repositories, " +
+            "but not build.gradle:buildscript.repositories - those ones are for gradle plugin metadata.\n\n" +
             "If your build fails to recognize the syntax of new Java versions, enable Jabel in your " +
-            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties.")
+            "gradle.properties. See how it's done in GTNH ExampleMod/gradle.properties. " +
+            "However, keep in mind that Jabel enables only syntax features, but not APIs that were introduced in " +
+            "Java 9 or later.")
     }
 }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,12 +4,12 @@ dependencies {
     compileOnly('com.google.auto.value:auto-value-annotations:1.8.2')
     annotationProcessor('com.google.auto.value:auto-value:1.8.2')
 
-    api('com.github.GTNewHorizons:NotEnoughItems:2.3.51-GTNH:dev')
+    api('com.github.GTNewHorizons:NotEnoughItems:2.3.54-GTNH:dev')
 
-    api('com.github.GTNewHorizons:DetravScannerMod:1.7.1:dev') {transitive=false}
+    api('com.github.GTNewHorizons:DetravScannerMod:1.7.2:dev') {transitive=false}
     api('com.github.GTNewHorizons:EnderStorage:1.4.12:dev') {transitive=false}
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.24:dev')
-    api('com.github.GTNewHorizons:GTplusplus:1.9.6:dev')
-    api('com.github.GTNewHorizons:NewHorizonsCoreMod:2.1.13:dev')
-    api('com.github.GTNewHorizons:bartworks:0.7.6:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.43.86:dev')
+    api('com.github.GTNewHorizons:GTplusplus:1.9.45:dev')
+    api('com.github.GTNewHorizons:NewHorizonsCoreMod:2.1.57:dev')
+    api('com.github.GTNewHorizons:bartworks:0.7.17:dev')
 }

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/api/diagram/DiagramGroup.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/api/diagram/DiagramGroup.java
@@ -283,16 +283,17 @@ public class DiagramGroup implements ICraftingHandler, IUsageHandler {
     public boolean mouseScrolled(GuiRecipe<?> gui, int scroll, int recipe) {
         ScrollDirection direction = scroll > 0 ? ScrollDirection.UP : ScrollDirection.DOWN;
 
-        if (mouseInBounds() && NEIClientUtils.shiftKey()) {
-            diagramState.scroll(direction);
-            return true;
+        if (mouseInBounds()) {
+            if (NEIClientUtils.shiftKey()) {
+                diagramState.scroll(direction);
+                return true;
+            }
+            if (!ConfigOptions.DISABLE_PAGE_SCROLL.get()) {
+                return scrollManager.mouseScroll(direction);
+            }
         }
 
-        if (scrollManager.mouseScroll(direction)) {
-            return true;
-        } else {
-            return ConfigOptions.DISABLE_PAGE_SCROLL.get();
-        }
+        return false;
     }
 
     public Optional<ItemStack> getStackUnderMouse(int recipe) {


### PR DESCRIPTION
Since https://github.com/GTNewHorizons/NotEnoughItems/pull/379 you can use the scroll wheel over the NEI tab bar to switch between recipe handlers. NEI Custom Diagrams overwrote that behavior since it didn't always check whether the mouse is actually over the diagram while scrolling. This reworks the logic to fix that.