### PR TITLE
Manual merge of v1.5.5 from upstream

### DIFF
--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/debug/nbtviewer/NbtViewer.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/debug/nbtviewer/NbtViewer.java
@@ -69,7 +69,7 @@ public final class NbtViewer implements DiagramGenerator {
         String nbtText = NbtUtil.prettyPrintNbt(nbt.toString());
         Iterable<String> lines = Splitter.on('\n').split(nbtText);
         layoutBuilder.addAllLabels(
-                Text.multiLineBuilder(Grid.GRID.grid(-1, 1), Grid.Direction.SE)
+                Text.multiLineBuilder(Grid.GRID.edge(0, 1, Grid.Direction.W), Grid.Direction.SE)
                         .setSmall(ConfigOptions.NBT_VIEWER_SMALL_TEXT.get()).addAllLines(lines).build());
 
         return layoutBuilder.build();

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/DiagramBuilder.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/DiagramBuilder.java
@@ -212,7 +212,21 @@ class DiagramBuilder {
                         LabelHandler.ItemLabel.ELECTRIC_BLAST_FURNACE,
                         LayoutHandler.AdditionalRecipeLabelPositions.ELECTRIC_BLAST_FURNACE,
                         RecipeHandler.RecipeMap.BLAST_FURNACE,
-                        Optional.of(rawOre)));
+                        // As of the time of this comment,
+                        // looks like there is exactly one crushed ore recipe: lead. Weird ¯\(°_o)/¯
+                        Optional.of(rawOre),
+                        crushedOreOptional));
+
+        // There's some redundancy here, in that we already show chemical bath recipes for
+        // sodium persulfate and mercury, and crushed ore.
+        // If it's an issue, we can add logic to filter those out here.
+        additionalRecipeOutputs.addAll(
+                addAdditionalRecipesInteractable(
+                        LabelHandler.ItemLabel.CHEMICAL_BATH,
+                        LayoutHandler.AdditionalRecipeLabelPositions.CHEMICAL_BATH,
+                        RecipeHandler.RecipeMap.CHEMICAL_BATH,
+                        crushedOreOptional,
+                        purifiedOreOptional));
 
         additionalRecipeOutputs.addAll(
                 addAdditionalRecipesInteractable(
@@ -221,6 +235,16 @@ class DiagramBuilder {
                         RecipeHandler.RecipeMap.CHEMICAL_REACTOR,
                         crushedOreOptional,
                         purifiedOreOptional));
+
+        additionalRecipeOutputs.addAll(
+                addAdditionalRecipesInteractable(
+                        LabelHandler.ItemLabel.MIXER,
+                        LayoutHandler.AdditionalRecipeLabelPositions.MIXER,
+                        RecipeHandler.RecipeMap.MIXER,
+                        crushedOreOptional,
+                        purifiedOreOptional,
+                        impureDustOptional,
+                        purifiedDustOptional));
 
         additionalRecipeOutputs.addAll(
                 addAdditionalRecipesInteractable(

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/LabelHandler.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/LabelHandler.java
@@ -27,6 +27,7 @@ class LabelHandler {
         FURNACE(ItemList.Machine_HV_E_Furnace, "furnacelabel"),
         ELECTRIC_BLAST_FURNACE(ItemList.Machine_Multi_BlastFurnace, "electricblastfurnacelabel"),
         CHEMICAL_REACTOR(ItemList.Machine_HV_ChemicalReactor, "chemicalreactorlabel"),
+        MIXER(ItemList.Machine_HV_Mixer, "mixerlabel"),
         AUTOCLAVE(ItemList.Machine_HV_Autoclave, "autoclavelabel");
 
         final ItemList item;

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/LayoutHandler.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/LayoutHandler.java
@@ -48,8 +48,10 @@ class LayoutHandler {
 
         static final Point FURNACE = Grid.GRID.grid(2, 0);
         static final Point ELECTRIC_BLAST_FURNACE = Grid.GRID.grid(4, 0);
-        static final Point CHEMICAL_REACTOR = Grid.GRID.grid(6, 0);
-        static final Point AUTOCLAVE = Grid.GRID.grid(8, 0);
+        static final Point CHEMICAL_BATH = Grid.GRID.grid(6, 0);
+        static final Point CHEMICAL_REACTOR = Grid.GRID.grid(8, 0);
+        static final Point MIXER = Grid.GRID.grid(10, 0);
+        static final Point AUTOCLAVE = Grid.GRID.grid(12, 0);
     }
 
     private final DiagramGroupInfo info;

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/RecipeHandler.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/RecipeHandler.java
@@ -48,6 +48,7 @@ class RecipeHandler {
         CHEMICAL_BATH(RecipeMaps.chemicalBathRecipes),
         CHEMICAL_REACTOR(RecipeMaps.chemicalReactorRecipes),
         ELECTROMAGNETIC_SEPARATOR(RecipeMaps.electroMagneticSeparatorRecipes),
+        MIXER(RecipeMaps.mixerRecipes),
         AUTOCLAVE(RecipeMaps.autoclaveRecipes);
 
         final gregtech.api.recipe.RecipeMap<?> recipeMap;

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/recipedebugger/RecipeHandler.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/recipedebugger/RecipeHandler.java
@@ -102,7 +102,7 @@ class RecipeHandler {
 
         /*
          * Assembly line recipes don't conflict usually since they are position-dependent. So it's disabled.
-         * ASSEMBLY_LINE( RecipeMaps.assemblylineVisualRecipes, ItemList.Machine_Multi_Assemblyline,
+         * ASSEMBLY_LINE(RecipeMaps.assemblylineVisualRecipes, ItemList.Machine_Multi_Assemblyline,
          * "assemblylinelabel"),
          */
 
@@ -124,9 +124,13 @@ class RecipeHandler {
         FLUID_HEATER(RecipeMaps.fluidHeaterRecipes, ItemList.Machine_HV_FluidHeater, "fluidheaterlabel"),
         DISTILLERY(RecipeMaps.distilleryRecipes, ItemList.Machine_HV_Distillery, "distillerylabel"),
         FERMENTER(RecipeMaps.fermentingRecipes, ItemList.Machine_HV_Fermenter, "fermenterlabel"),
-        // Fluid Solidifier
-        // Be warned: this thing has way too many recipes (~46k), and they all have similar
-        // components! Expect extreme slow-down if you want to add it.
+
+        /*
+         * Fluid Solidifier Be warned: this thing has way too many recipes (~46k), and they all have similar components!
+         * Expect extreme slow-down if you want to add it. FLUID_SOLIDIFIER(RecipeMaps.fluidSolidifierRecipes,
+         * ItemList.Machine_HV_FluidSolidifier, "fluidsolidifierlabel"),
+         */
+
         FLUID_EXTRACTOR(RecipeMaps.fluidExtractionRecipes, ItemList.Machine_HV_FluidExtractor, "fluidextractorlabel"),
         PACKAGER(RecipeMaps.packagerRecipes, ItemList.Machine_HV_Boxinator, "packagerlabel"),
         UNPACKAGER(RecipeMaps.unpackagerRecipes, ItemList.Machine_HV_Unboxinator, "unpackagerlabel"),
@@ -136,11 +140,8 @@ class RecipeHandler {
         ELECTRIC_BLAST_FURNACE(RecipeMaps.blastFurnaceRecipes, ItemList.Machine_Multi_BlastFurnace,
                 "electricblastfurnacelabel"),
         PLASMA_FORGE(RecipeMaps.plasmaForgeRecipes, ItemList.Machine_Multi_PlasmaForge, "plasmaforgelabel"),
-        // Commenting this one out for now, for backward compatibility. Uncomment later.
-        /*
-         * TRANSCENDENT_PLASMA_MIXER( RecipeMaps.transcendentPlasmaMixerRecipes,
-         * ItemList.Machine_Multi_TranscendentPlasmaMixer, "transcendentplasmamixerlabel"),
-         */
+        TRANSCENDENT_PLASMA_MIXER(RecipeMaps.transcendentPlasmaMixerRecipes,
+                ItemList.Machine_Multi_TranscendentPlasmaMixer, "transcendentplasmamixerlabel"),
         // Fake Space Project
         BRICKED_BLAST_FURNACE(RecipeMaps.primitiveBlastRecipes, ItemList.Machine_Bricked_BlastFurnace,
                 "brickedblastfurnacelabel"),

--- a/src/main/resources/assets/neicustomdiagram/lang/en_US.lang
+++ b/src/main/resources/assets/neicustomdiagram/lang/en_US.lang
@@ -197,6 +197,7 @@ neicustomdiagram.generators.gregtech5.oreprocessing.thermalcentrifugeslot=Therma
 neicustomdiagram.generators.gregtech5.oreprocessing.furnacelabel=Additional Furnace recipes
 neicustomdiagram.generators.gregtech5.oreprocessing.electricblastfurnacelabel=Additional Electric Blast Furnace recipes
 neicustomdiagram.generators.gregtech5.oreprocessing.chemicalreactorlabel=Additional Chemical Reactor recipes
+neicustomdiagram.generators.gregtech5.oreprocessing.mixerlabel=Additional Mixer recipes
 neicustomdiagram.generators.gregtech5.oreprocessing.autoclavelabel=Additional Autoclave recipes
 neicustomdiagram.generators.gregtech5.oreprocessing.additionalrecipeoutputsslot=Additional recipe outputs
 
@@ -234,6 +235,7 @@ neicustomdiagram.generators.gregtech5.recipedebugger.brewerylabel=Brewery recipe
 neicustomdiagram.generators.gregtech5.recipedebugger.fluidheaterlabel=Fluid Heater recipe
 neicustomdiagram.generators.gregtech5.recipedebugger.distillerylabel=Distillery recipe
 neicustomdiagram.generators.gregtech5.recipedebugger.fermenterlabel=Fermenter recipe
+neicustomdiagram.generators.gregtech5.recipedebugger.fluidsolidifierlabel=Fluid Solidifier recipe
 neicustomdiagram.generators.gregtech5.recipedebugger.fluidextractorlabel=Fluid Extractor recipe
 neicustomdiagram.generators.gregtech5.recipedebugger.packagerlabel=Packager recipe
 neicustomdiagram.generators.gregtech5.recipedebugger.unpackagerlabel=Unpackager recipe

--- a/src/main/resources/assets/neicustomdiagram/lang/zh_CN.lang
+++ b/src/main/resources/assets/neicustomdiagram/lang/zh_CN.lang
@@ -197,6 +197,7 @@ neicustomdiagram.generators.gregtech5.oreprocessing.thermalcentrifugeslot=热力
 neicustomdiagram.generators.gregtech5.oreprocessing.furnacelabel=附加熔炉合成表
 neicustomdiagram.generators.gregtech5.oreprocessing.electricblastfurnacelabel=附加工业高炉合成表
 neicustomdiagram.generators.gregtech5.oreprocessing.chemicalreactorlabel=附加化学反应釜合成表
+neicustomdiagram.generators.gregtech5.oreprocessing.mixerlabel=附加搅拌机合成表
 neicustomdiagram.generators.gregtech5.oreprocessing.autoclavelabel=附加高压釜合成表
 neicustomdiagram.generators.gregtech5.oreprocessing.additionalrecipeoutputsslot=附加合成表输出
 
@@ -234,6 +235,7 @@ neicustomdiagram.generators.gregtech5.recipedebugger.brewerylabel=酿造室合�
 neicustomdiagram.generators.gregtech5.recipedebugger.fluidheaterlabel=流体加热器合成表
 neicustomdiagram.generators.gregtech5.recipedebugger.distillerylabel=蒸馏室合成表
 neicustomdiagram.generators.gregtech5.recipedebugger.fermenterlabel=发酵槽合成表
+neicustomdiagram.generators.gregtech5.recipedebugger.fluidsolidifierlabel=Fluid Solidifier recipe
 neicustomdiagram.generators.gregtech5.recipedebugger.fluidextractorlabel=流体提取机合成表
 neicustomdiagram.generators.gregtech5.recipedebugger.packagerlabel=打包机合成表
 neicustomdiagram.generators.gregtech5.recipedebugger.unpackagerlabel=解包器合成表


### PR DESCRIPTION
Changes:
 * Added chemical bath and mixer additional recipes to GT5 Ore Processing diagram
 * Fixed clipping on left edge of NBT Viewer diagram
 * Uncommented Transcendent Plasma Mixer in GT5 Recipe Debugger diagram

The updates to the ore processing diagram mean that it should now show outputs from recipes like:
 * Mixer recipe for making ruby juice
 * Special chem bath recipe for crushed ilmenite ore
 * Special EBF recipe for crushed lead ore