### PR TITLE
Put excessive logging behind a config

### DIFF
--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/DiagramBuilder.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/DiagramBuilder.java
@@ -22,6 +22,7 @@ import com.github.dcysteine.neicustomdiagram.api.diagram.matcher.ComponentDiagra
 import com.github.dcysteine.neicustomdiagram.api.diagram.tooltip.Tooltip;
 import com.github.dcysteine.neicustomdiagram.api.draw.Point;
 import com.github.dcysteine.neicustomdiagram.main.Logger;
+import com.github.dcysteine.neicustomdiagram.main.config.ConfigOptions;
 import com.github.dcysteine.neicustomdiagram.util.ComponentTransformer;
 import com.github.dcysteine.neicustomdiagram.util.gregtech5.GregTechFluidDictUtil;
 import com.github.dcysteine.neicustomdiagram.util.gregtech5.GregTechOreDictUtil;
@@ -146,19 +147,24 @@ class DiagramBuilder {
                     centrifugedOreOptional = Optional.empty();
                 }
             } else {
-                Logger.GREGTECH_5_ORE_PROCESSING.warn(
-                        "Crushed ore and purified ore have different thermal centrifuge outputs:"
-                                + "\n[{}]\n ->\n[{}]\n\n[{}]\n ->\n[{}]",
-                        crushedOre,
-                        crushedOreOutputs,
-                        purifiedOre,
-                        purifiedOreOutputs);
+                if (ConfigOptions.OREPROC_DEBUG_LOGGING.get()) {
+                    Logger.GREGTECH_5_ORE_PROCESSING.warn(
+                            "Crushed ore and purified ore have different thermal centrifuge outputs:"
+                                    + "\n[{}]\n ->\n[{}]\n\n[{}]\n ->\n[{}]",
+                            crushedOre,
+                            crushedOreOutputs,
+                            purifiedOre,
+                            purifiedOreOutputs);
+                } else {
+                    Logger.GREGTECH_5_ORE_PROCESSING
+                            .warn("Crushed and purified [{}] have different thermal centrifuge outputs.", crushedOre);
+                }
                 centrifugedOreOptional = Optional.empty();
             }
         } else {
             centrifugedOreOptional = crushedOreOptional.flatMap(crushedOre -> {
                 Logger.GREGTECH_5_ORE_PROCESSING.warn(
-                        "Crushed ore had thermal centrifuge recipe," + " but no ore washing plant recipe: [{}]",
+                        "Crushed ore had thermal centrifuge recipe, but no ore washing plant recipe: [{}]",
                         crushedOre);
                 return handleRecipes(
                         RecipeHandler.RecipeMap.THERMAL_CENTRIFUGE,
@@ -306,9 +312,8 @@ class DiagramBuilder {
 
         List<DisplayComponent> outputs = new ArrayList<>(outputsOptional.get());
         ComponentTransformer.removeComponent(outputs, STONE_DUST);
-        if (outputs.size() == 0) {
+        if (outputs.isEmpty()) {
             Logger.GREGTECH_5_ORE_PROCESSING.warn("Found no recipe outputs: [{}] [{}]", key, input);
-
             return Optional.empty();
         }
         diagramBuilder.autoInsertIntoSlotGroup(key).insertEachSafe(outputs);
@@ -339,9 +344,8 @@ class DiagramBuilder {
 
         List<DisplayComponent> outputs = new ArrayList<>(recipeOptional.get().outputs());
         ComponentTransformer.removeComponent(outputs, STONE_DUST);
-        if (outputs.size() == 0) {
+        if (outputs.isEmpty()) {
             Logger.GREGTECH_5_ORE_PROCESSING.warn("Found no recipe outputs: [{}] [{}]", key, input);
-
             return;
         }
         diagramBuilder.autoInsertIntoSlotGroup(key).insertIntoNextSlot(fluidDisplayItem.orElse(fluid))

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/RecipeHandler.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/oreprocessing/RecipeHandler.java
@@ -215,7 +215,6 @@ class RecipeHandler {
 
         if (outputs.size() > 1) {
             Logger.GREGTECH_5_ORE_PROCESSING.warn("Found {} recipes: [{}] [{}]", outputs.size(), recipeMap, input);
-
             return Optional.empty();
         } else if (outputs.isEmpty()) {
             return Optional.empty();

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/main/config/ConfigOptions.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/main/config/ConfigOptions.java
@@ -100,7 +100,7 @@ public final class ConfigOptions {
             Category.OPTIONS,
             "tooltip_max_cycle_count",
             8,
-            "Sets the maximum # of cycle components that will be shown in a tooltip" + " when <Shift> is held."
+            "Sets the maximum # of cycle components that will be shown in a tooltip when <Shift> is held."
                     + "\nSet to 0 to disable this feature.").register();
 
     public static final Option<Boolean> NBT_VIEWER_SMALL_TEXT = new BooleanOption(
@@ -114,6 +114,12 @@ public final class ConfigOptions {
             "nbt_viewer_newline_values",
             false,
             "Enables drawing values on a separate line in the NBT Viewer diagram.").register();
+
+    public static final Option<Boolean> OREPROC_DEBUG_LOGGING = new BooleanOption(
+            Category.OPTIONS,
+            "oreproc_debug_logging",
+            false,
+            "Enables more debug logging when failing to generate diagram for certain ore processing steps").register();
 
     public enum Category {
 


### PR DESCRIPTION
It reduces the place it takes in the log by a lot

BEFORE : 
![image](https://github.com/user-attachments/assets/ab91b2eb-6064-473d-a4fa-3c741f752d9c)


AFTER : 
![image](https://github.com/user-attachments/assets/74028556-3526-45e7-89fd-baca012a3da6)
