### PR TITLE
Add new boards and pico, quantum and planck circuits

### DIFF
--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/circuits/CircuitLineHandler.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/circuits/CircuitLineHandler.java
@@ -228,15 +228,30 @@ class CircuitLineHandler {
                                 GregTechOreDictUtil.getComponent(ItemList.Circuit_Biowaresupercomputer),
                                 GregTechOreDictUtil.getComponent(ItemList.Circuit_Biomainframe))
                         .build());
-        circuitLinesBuilder.add(
-                CircuitLine.builder().addBoard(GregTechOreDictUtil.getComponent(ItemList.Circuit_Board_Optical))
-                        .setStartTier(8)
-                        .addCircuits(
-                                GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalProcessor),
-                                GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalAssembly),
-                                GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalComputer),
-                                GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalMainframe))
-                        .build());
+        if (Registry.ModDependency.GTNH_CORE_MOD.isLoaded()) {
+            circuitLinesBuilder.add(
+                    CircuitLine.builder().addBoard(GregTechOreDictUtil.getComponent(ItemList.Circuit_Board_Optical))
+                            .setStartTier(8)
+                            .addCircuits(
+                                    GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalProcessor),
+                                    GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalAssembly),
+                                    GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalComputer),
+                                    GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalMainframe),
+                                    ItemComponent.create(NHItemList.PikoCircuit.get()),
+                                    ItemComponent.create(NHItemList.QuantumCircuit.get()),
+                                    ItemComponent.create(NHItemList.PlanckCircuit.get()))
+                            .build());
+        } else {
+            circuitLinesBuilder.add(
+                    CircuitLine.builder().addBoard(GregTechOreDictUtil.getComponent(ItemList.Circuit_Board_Optical))
+                            .setStartTier(8)
+                            .addCircuits(
+                                    GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalProcessor),
+                                    GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalAssembly),
+                                    GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalComputer),
+                                    GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalMainframe))
+                            .build());
+        }
         circuitLinesBuilder.add(
                 CircuitLine.builder().addBoard(GregTechOreDictUtil.getComponent(ItemList.Circuit_Board_Exotic))
                         .setStartTier(9)

--- a/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/circuits/CircuitLineHandler.java
+++ b/src/main/java/com/github/dcysteine/neicustomdiagram/generators/gregtech5/circuits/CircuitLineHandler.java
@@ -238,8 +238,7 @@ class CircuitLineHandler {
                                 GregTechOreDictUtil.getComponent(ItemList.Circuit_OpticalMainframe))
                         .build());
         circuitLinesBuilder.add(
-                CircuitLine.builder()
-                        // TODO board does not exist yet
+                CircuitLine.builder().addBoard(GregTechOreDictUtil.getComponent(ItemList.Circuit_Board_Exotic))
                         .setStartTier(9)
                         .addCircuits(
                                 GregTechOreDictUtil.getComponent(ItemList.Circuit_ExoticProcessor),
@@ -248,8 +247,7 @@ class CircuitLineHandler {
                                 GregTechOreDictUtil.getComponent(ItemList.Circuit_ExoticMainframe))
                         .build());
         circuitLinesBuilder.add(
-                CircuitLine.builder()
-                        // TODO board does not exist yet
+                CircuitLine.builder().addBoard(GregTechOreDictUtil.getComponent(ItemList.Circuit_Board_Cosmic))
                         .setStartTier(10)
                         .addCircuits(
                                 GregTechOreDictUtil.getComponent(ItemList.Circuit_CosmicProcessor),
@@ -258,8 +256,7 @@ class CircuitLineHandler {
                                 GregTechOreDictUtil.getComponent(ItemList.Circuit_CosmicMainframe))
                         .build());
         circuitLinesBuilder.add(
-                CircuitLine.builder()
-                        // TODO board does not exist yet
+                CircuitLine.builder().addBoard(GregTechOreDictUtil.getComponent(ItemList.Circuit_Board_Transcendent))
                         .setStartTier(11)
                         .addCircuits(
                                 GregTechOreDictUtil.getComponent(ItemList.Circuit_TranscendentProcessor),


### PR DESCRIPTION
This PR adds the recently added exotic+ circuit boards to the main circuit diagram, and adds pico, quantum and planck circuits as a continuation of the optical line (since thats what they are and they were missing).

<img width="410" height="785" alt="image" src="https://github.com/user-attachments/assets/f18206d0-176c-4eef-8092-0f2d2f2cd6e1" />
